### PR TITLE
Grab current build data if there are multiple

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.coravy.hudson.plugins.github</groupId>
     <artifactId>github</artifactId>
-    <version>1.43.0</version>
+    <version>99.43.0</version>
     <packaging>hpi</packaging>
 
     <name>GitHub plugin</name>
@@ -39,7 +39,7 @@
         <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
         <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
-        <tag>v1.43.0</tag>
+        <tag>v99.43.0</tag>
     </scm>
     <issueManagement>
         <system>JIRA</system>

--- a/src/main/java/org/jenkinsci/plugins/github/util/BuildDataHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/github/util/BuildDataHelper.java
@@ -35,7 +35,7 @@ public final class BuildDataHelper {
      * @return the build data related to the project, null if not found
      */
     public static BuildData calculateBuildData(
-        String parentName, String parentFullName, List<BuildData> buildDataList
+        int buildNumber, String parentName, String parentFullName, List<BuildData> buildDataList
     ) {
 
         if (buildDataList == null) {
@@ -46,6 +46,8 @@ public final class BuildDataHelper {
             return buildDataList.get(0);
         }
 
+        // This relies upon very specific folder naming schemes and should be replaced with a more generic solution
+        // See https://issues.jenkins-ci.org/browse/JENKINS-60534
         String projectName = parentFullName.replace(parentName, "");
 
         if (projectName.endsWith("/")) {
@@ -57,6 +59,15 @@ public final class BuildDataHelper {
 
             for (String remoteUrl : remoteUrls) {
                 if (remoteUrl.contains(projectName)) {
+                    return buildData;
+                }
+            }
+        }
+
+        // Sometimes the previous build data is attached along with the current one, and we just want the current one
+        for (BuildData buildData : buildDataList) {
+            for (Build build : buildData.buildsByBranchName.values()) {
+                if (build.getBuildNumber() == buildNumber) {
                     return buildData;
                 }
             }
@@ -80,7 +91,7 @@ public final class BuildDataHelper {
         Job<?, ?> parent = build.getParent();
 
         BuildData buildData = calculateBuildData(
-            parent.getName(), parent.getFullName(), buildDataList
+            build.number, parent.getName(), parent.getFullName(), buildDataList
         );
 
         if (buildData == null) {

--- a/src/test/java/org/jenkinsci/plugins/github/util/BuildDataHelperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/util/BuildDataHelperTest.java
@@ -41,7 +41,7 @@ public class BuildDataHelperTest {
 			buildDataList.add(projectBuildData);
 
 			BuildData buildData = BuildDataHelper.calculateBuildData(
-				"master", "project/master", buildDataList);
+				1, "master", "project/master", buildDataList);
 
 			assertThat("should fetch project build data", buildData, is(projectBuildData));
 		}
@@ -66,7 +66,7 @@ public class BuildDataHelperTest {
 			Collections.addAll(buildDataList, sharedLibBuildData, realProjectBuildData);
 
 			BuildData buildData = BuildDataHelper.calculateBuildData(
-				"master", "project/master", buildDataList);
+				1, "master", "project/master", buildDataList);
 
 			assertThat("should not fetch shared library build data", buildData, not(sharedLibBuildData));
 			assertThat("should fetch project build data", buildData, is(realProjectBuildData));
@@ -76,7 +76,7 @@ public class BuildDataHelperTest {
 		@Issue("JENKINS-53149")
 		public void shouldCalculateDataBuildFromProjectWithEmptyBuildDatas() throws Exception {
 			BuildData buildData = BuildDataHelper.calculateBuildData(
-				"master", "project/master", Collections.EMPTY_LIST);
+				1, "master", "project/master", Collections.EMPTY_LIST);
 
 			assertThat("should be null", buildData, nullValue());
 		}
@@ -85,7 +85,7 @@ public class BuildDataHelperTest {
 		@Issue("JENKINS-53149")
 		public void shouldCalculateDataBuildFromProjectWithNullBuildDatas() throws Exception {
 			BuildData buildData = BuildDataHelper.calculateBuildData(
-				"master", "project/master", null);
+				1, "master", "project/master", null);
 
 			assertThat("should be null", buildData, nullValue());
 		}
@@ -110,7 +110,7 @@ public class BuildDataHelperTest {
 			buildDataList.add(projectBuildData);
 
 			BuildData buildData = BuildDataHelper.calculateBuildData(
-				"master", ORGANIZATION_NAME + "/project/master", buildDataList);
+				1, "master", ORGANIZATION_NAME + "/project/master", buildDataList);
 
 			assertThat("should fetch project build data", buildData, is(projectBuildData));
 		}
@@ -135,7 +135,7 @@ public class BuildDataHelperTest {
 			Collections.addAll(buildDataList, sharedLibBuildData, realProjectBuildData);
 
 			BuildData buildData = BuildDataHelper.calculateBuildData(
-				"master", ORGANIZATION_NAME + "/project/master", buildDataList);
+				1, "master", ORGANIZATION_NAME + "/project/master", buildDataList);
 
 			assertThat("should not fetch shared library build data", buildData, not(sharedLibBuildData));
 			assertThat("should fetch project build data", buildData, is(realProjectBuildData));
@@ -145,7 +145,7 @@ public class BuildDataHelperTest {
 		@Issue("JENKINS-53149")
 		public void shouldCalculateDataBuildFromProjectWithEmptyBuildDatas() throws Exception {
 			BuildData buildData = BuildDataHelper.calculateBuildData(
-				"master", ORGANIZATION_NAME + "/project/master", Collections.EMPTY_LIST);
+				1, "master", ORGANIZATION_NAME + "/project/master", Collections.EMPTY_LIST);
 
 			assertThat("should be null", buildData, nullValue());
 		}
@@ -154,7 +154,7 @@ public class BuildDataHelperTest {
 		@Issue("JENKINS-53149")
 		public void shouldCalculateDataBuildFromProjectWithNullBuildDatas() throws Exception {
 			BuildData buildData = BuildDataHelper.calculateBuildData(
-				"master", ORGANIZATION_NAME + "/project/master", null);
+				1, "master", ORGANIZATION_NAME + "/project/master", null);
 
 			assertThat("should be null", buildData, nullValue());
 		}


### PR DESCRIPTION
This should hopefully fix our issue where builds are failing due to the previous build's build data being attached along with the current one.